### PR TITLE
[fix] #27 统一红外收发参数顺序为 (addr, cmd, repeat)

### DIFF
--- a/communication/irtranslation_driver/code/ir_rx/__init__.py
+++ b/communication/irtranslation_driver/code/ir_rx/__init__.py
@@ -43,7 +43,7 @@ class IR_RX:
             初始化红外接收对象，设置引脚、中断和回调函数。
         _cb_pin(line) -> None:
             引脚中断回调，记录信号沿的时间戳。
-        do_callback(cmd: int, addr: int, ext: int, thresh: int = 0) -> None:
+        do_callback(cmd: int, addr: int, thresh: int = 0) -> None:
             执行用户回调或错误回调。
         error_function(func) -> None:
             设置错误处理回调函数。
@@ -73,7 +73,7 @@ class IR_RX:
             Initialize IR receiver, configure pin, IRQ, and callback.
         _cb_pin(line) -> None:
             Pin IRQ callback. Store edge timestamps.
-        do_callback(cmd: int, addr: int, ext: int, thresh: int = 0) -> None:
+        do_callback(cmd: int, addr: int, thresh: int = 0) -> None:
             Run user callback or error handler.
         error_function(func) -> None:
             Set error handler function.
@@ -103,7 +103,7 @@ class IR_RX:
             pin (Pin): 用于接收红外信号的输入引脚。
             nedges (int): 需要捕获的边沿数量。
             tblock (int): 定时器超时周期（ms）。
-            callback (function): 用户定义的回调函数，参数为 (cmd, addr, ext, *args)。
+            callback (function): 用户定义的回调函数，参数为 (addr, cmd, repeat, *args)。
             *args: 传递给回调函数的额外参数。
 
         Notes:
@@ -118,7 +118,7 @@ class IR_RX:
             pin (Pin): Input pin for IR signal.
             nedges (int): Number of edges to capture.
             tblock (int): Timer timeout in ms.
-            callback (function): User callback function (cmd, addr, ext, *args).
+            callback (function): User callback function (addr, cmd, repeat, *args).
             *args: Extra arguments passed to callback.
 
         Notes:
@@ -169,20 +169,20 @@ class IR_RX:
             self._times[self.edge] = t
             self.edge += 1
 
-    def do_callback(self, cmd: int, addr: int, ext: int, thresh: int = 0) -> None:
+    def do_callback(self, cmd: int, addr: int, thresh: int = 0) -> None:
         """
         执行用户回调函数或错误处理函数。
 
         Args:
             cmd (int): 接收到的命令码或错误码。
             addr (int): 地址字段。
-            ext (int): 扩展字段。
             thresh (int): 最小阈值，cmd 小于该值时视为错误。
 
-
         Notes:
-            当 cmd >= thresh 时调用用户回调。
-            否则调用错误处理函数。
+            当 cmd >= thresh 时调用用户回调，否则调用错误处理函数。
+            用户回调函数签名为 callback(addr, cmd, repeat, *args)，参数顺序与
+            发射端 transmit(addr, data) 保持一致（addr 在前、cmd 在后）；
+            repeat 为 True 表示该帧为重复码（长按）。
 
         ==========================================
 
@@ -191,15 +191,18 @@ class IR_RX:
         Args:
             cmd (int): Command or error code.
             addr (int): Address field.
-            ext (int): Extension field.
             thresh (int): Threshold. If cmd < thresh => error.
 
         Notes:
             Calls user callback if cmd valid, else error function.
+            User callback signature is callback(addr, cmd, repeat, *args); the
+            argument order matches the transmitter's transmit(addr, data) so RX
+            and TX stay consistent (addr first, cmd second). repeat is True when
+            the frame is an NEC repeat (long-press) code.
         """
         self.edge = 0
         if cmd >= thresh:
-            self.callback(cmd, addr, ext, *self.args)
+            self.callback(addr, cmd, cmd == self.REPEAT, *self.args)
         else:
             self._errf(cmd)
 

--- a/communication/irtranslation_driver/code/ir_rx/acquire.py
+++ b/communication/irtranslation_driver/code/ir_rx/acquire.py
@@ -185,7 +185,7 @@ class IR_GET(IR_RX):
 
             print()
         self.data = burst
-        self.do_callback(0, 0, 0)
+        self.do_callback(0, 0)
 
     def acquire(self) -> list:
         """

--- a/communication/irtranslation_driver/code/ir_rx/nec.py
+++ b/communication/irtranslation_driver/code/ir_rx/nec.py
@@ -73,7 +73,7 @@ class NEC_ABC(IR_RX):
             pin (Pin): 接收 IR 信号的引脚。
             extended (bool): 是否使用扩展地址模式。
             samsung (bool): 是否为 Samsung 协议模式。
-            callback (function): 用户回调函数，接收 cmd, addr, ext。
+            callback (function): 用户回调函数，接收 addr, cmd, repeat。
             *args: 可选附加参数传递给回调函数。
 
         Notes:
@@ -88,7 +88,7 @@ class NEC_ABC(IR_RX):
             pin (Pin): Input pin for IR signal.
             extended (bool): Enable extended address mode.
             samsung (bool): Samsung protocol mode.
-            callback (function): User callback accepting cmd, addr, ext.
+            callback (function): User callback accepting addr, cmd, repeat.
             *args: Optional extra arguments passed to callback.
 
         Notes:
@@ -163,7 +163,8 @@ class NEC_ABC(IR_RX):
         except RuntimeError as e:
             cmd = e.args[0]
             addr = self._addr if cmd == self.REPEAT else 0
-        self.do_callback(cmd, addr, 0, self.REPEAT)
+        # thresh=REPEAT: repeat codes (cmd == -1) still reach the callback; errors (<= -2) go to _errf
+        self.do_callback(cmd, addr, self.REPEAT)
 
 
 class NEC_16(NEC_ABC):
@@ -295,13 +296,13 @@ class NEC_8(NEC_ABC):
             初始化 NEC_8 对象，设置固定模式和回调函数。
         decode(_) -> None:
             解析接收到的脉冲数据（继承自 NEC_ABC）。
-        do_callback(cmd: int, addr: int, data: int, repeat: int) -> None:
+        do_callback(cmd: int, addr: int, thresh: int = 0) -> None:
             调用用户回调（继承自 NEC_ABC）。
 
     Notes:
         NEC_8 始终为 8-bit 地址模式。
         decode 方法会对收到的数据进行校验，错误时通过回调返回错误码。
-        回调函数签名: func(cmd: int, addr: int, data: int, repeat: int)
+        回调函数签名: func(addr: int, cmd: int, repeat: bool)
 
     ==========================================
 
@@ -322,13 +323,13 @@ class NEC_8(NEC_ABC):
             Initialize NEC_8 object with fixed mode and user callback.
         decode(_) -> None:
             Decode received pulse data (from NEC_ABC).
-        do_callback(cmd: int, addr: int, data: int, repeat: int) -> None:
+        do_callback(cmd: int, addr: int, thresh: int = 0) -> None:
             Call user callback (from NEC_ABC).
 
     Notes:
         NEC_8 always uses 8-bit address mode.
         decode method validates received data and reports errors via callback.
-        Callback signature: func(cmd: int, addr: int, data: int, repeat: int)
+        Callback signature: func(addr: int, cmd: int, repeat: bool)
     """
 
     def __init__(self, pin, callback, *args):
@@ -342,7 +343,7 @@ class NEC_8(NEC_ABC):
 
         Notes:
             NEC_8 固定为 8-bit 地址模式，非扩展模式，非 Samsung 模式
-            回调函数签名一般为 func(cmd:int, addr:int, data:int, repeat:int)
+            回调函数签名一般为 func(addr:int, cmd:int, repeat:bool)
             初始化会设置内部捕获缓冲、模式标志等
             继承自 NEC_ABC，所以 *args 会传给父类处理
 
@@ -357,7 +358,7 @@ class NEC_8(NEC_ABC):
 
         Notes:
             NEC_8 uses fixed 8-bit address mode, non-extended, non-Samsung
-            Callback signature typically: func(cmd:int, addr:int, data:int, repeat:int)
+            Callback signature typically: func(addr:int, cmd:int, repeat:bool)
             Initializes internal buffers and mode flags
             *args are forwarded to NEC_ABC parent initialization
         """


### PR DESCRIPTION
## 任务背景

issue #27（红外通信部分存在问题）：`ir_rx` 解码后回调用户函数的参数顺序为 `(cmd, addr, ext)`，而 `ir_tx.transmit(addr, data)` 与 `main.py` 均按 `(addr, cmd)` 顺序使用，导致**收发参数错位**。同时 README 与 main.py 早已按 `ir_callback(addr, cmd, repeat)` 编写，但实现并未对齐——`repeat` 位实际收到的是恒为 0 的 `ext`。

## 修改内容

均在 `communication/irtranslation_driver/code/ir_rx/` 下：

1. `__init__.py` · `IR_RX.do_callback`：回调改为 `self.callback(addr, cmd, cmd == self.REPEAT, *self.args)`——参数顺序与发射端 `transmit(addr, data)` 对齐（addr 在前、cmd 在后），第三位为真正的 `repeat` 布尔（长按重复码为 True）。
2. 移除 `do_callback` 中已不再使用的 `ext` 形参，并同步更新 `nec.py`（`do_callback(cmd, addr, self.REPEAT)`）与 `acquire.py`（`do_callback(0, 0)`）两处唯一调用点。
3. 同步 `__init__.py` / `nec.py` 中描述回调签名的 docstring 为 `(addr, cmd, repeat)`。

错误路由不变：`REPEAT = -1` 仍 >= 阈值 `thresh=REPEAT`，可正常回调；真正的错误码（`-2 ~ -7`）仍走 `_errf`。`main.py` 与 `README.md` 本就正确，未改动。

## 自测情况

PC 端用 mock 的 `machine` / `time` 运行真实 `ir_rx` 代码做了往返验证：

- `decode()` 往返：发送 `(0x10, 0x20)` → 回调收到 `(0x10, 0x20, False)`；
- 重复码：回调收到 `(last_addr, -1, True)`；
- 错误码：路由到 `error_function`，不进用户回调；
- `ir_tx` 的 `transmit` / `tx` 签名确认为 addr 在前、data 在后。

`black --line-length=150 --check` 通过；改动未引入新的 `code_checker.py` 失败项。
（本仓驱动无 PC 端测试框架、以 `main.py` 在硬件上验证为准，故未新增测试文件以保持仓库惯例。）

Closes #27